### PR TITLE
disabled ViewController lifecycle method swizzling as the implementat…

### DIFF
--- a/CoconutKit.podspec
+++ b/CoconutKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name = 'CoconutKit'
-  s.version = '2.1.2'
+  s.version = '2.1.3'
   s.license = 'MIT'
   s.summary = 'CoconutKit is a library of high-quality iOS components.'
   s.homepage = 'https://github.com/defagos/CoconutKit'
   s.author = { 'Samuel Défago' => 'defagos@gmail.com' }
-  s.source = { :git => 'https://github.com/defagos/CoconutKit.git', :tag => '2.1.2' }
+  s.source = { :git => 'https://github.com/cbdr/CoconutKit.git', :tag => '2.1.3' }
   s.social_media_url = 'http://twitter.com/defagos'
   s.platform = :ios, '7.0'
   

--- a/CoconutKit/Sources/ViewControllers/UIViewController+HLSExtensions.m
+++ b/CoconutKit/Sources/ViewControllers/UIViewController+HLSExtensions.m
@@ -180,7 +180,7 @@ static void swizzled_UIViewController__viewDidDisappear_Imp(UIViewController *se
 #pragma mark Class methods
 
 + (void)load
-{ 
+{
     s_UIViewController__initWithNibName_bundle_Imp = (id (*)(id, SEL, id, id))hls_class_swizzleSelector(self,
                                                                                                         @selector(initWithNibName:bundle:),
                                                                                                         (IMP)swizzled_UIViewController__initWithNibName_bundle_Imp);

--- a/CoconutKit/Sources/ViewControllers/UIViewController+HLSExtensions.m
+++ b/CoconutKit/Sources/ViewControllers/UIViewController+HLSExtensions.m
@@ -181,27 +181,28 @@ static void swizzled_UIViewController__viewDidDisappear_Imp(UIViewController *se
 
 + (void)load
 {
-    s_UIViewController__initWithNibName_bundle_Imp = (id (*)(id, SEL, id, id))hls_class_swizzleSelector(self,
-                                                                                                        @selector(initWithNibName:bundle:),
-                                                                                                        (IMP)swizzled_UIViewController__initWithNibName_bundle_Imp);
-    s_UIViewController__initWithCoder_Imp = (id (*)(id, SEL, id))hls_class_swizzleSelector(self,
-                                                                                           @selector(initWithCoder:),
-                                                                                           (IMP)swizzled_UIViewController__initWithCoder_Imp);
-    s_UIViewController__viewDidLoad_Imp = (void (*)(id, SEL))hls_class_swizzleSelector(self,
-                                                                                       @selector(viewDidLoad),
-                                                                                       (IMP)swizzled_UIViewController__viewDidLoad_Imp);
-    s_UIViewController__viewWillAppear_Imp = (void (*)(id, SEL, BOOL))hls_class_swizzleSelector(self,
-                                                                                                @selector(viewWillAppear:),
-                                                                                                (IMP)swizzled_UIViewController__viewWillAppear_Imp);
-    s_UIViewController__viewDidAppear_Imp = (void (*)(id, SEL, BOOL))hls_class_swizzleSelector(self,
-                                                                                               @selector(viewDidAppear:),
-                                                                                               (IMP)swizzled_UIViewController__viewDidAppear_Imp);
-    s_UIViewController__viewWillDisappear_Imp = (void (*)(id, SEL, BOOL))hls_class_swizzleSelector(self,
-                                                                                                   @selector(viewWillDisappear:),
-                                                                                                   (IMP)swizzled_UIViewController__viewWillDisappear_Imp);
-    s_UIViewController__viewDidDisappear_Imp = (void (*)(id, SEL, BOOL))hls_class_swizzleSelector(self,
-                                                                                                  @selector(viewDidDisappear:),
-                                                                                                  (IMP)swizzled_UIViewController__viewDidDisappear_Imp);
+    // disabled the method swizzling as the implementation breaks 3rd party keyboards
+    // s_UIViewController__initWithNibName_bundle_Imp = (id (*)(id, SEL, id, id))hls_class_swizzleSelector(self,
+    //                                                                                                     @selector(initWithNibName:bundle:),
+    //                                                                                                     (IMP)swizzled_UIViewController__initWithNibName_bundle_Imp);
+    // s_UIViewController__initWithCoder_Imp = (id (*)(id, SEL, id))hls_class_swizzleSelector(self,
+    //                                                                                        @selector(initWithCoder:),
+    //                                                                                        (IMP)swizzled_UIViewController__initWithCoder_Imp);
+    // s_UIViewController__viewDidLoad_Imp = (void (*)(id, SEL))hls_class_swizzleSelector(self,
+    //                                                                                    @selector(viewDidLoad),
+    //                                                                                    (IMP)swizzled_UIViewController__viewDidLoad_Imp);
+    // s_UIViewController__viewWillAppear_Imp = (void (*)(id, SEL, BOOL))hls_class_swizzleSelector(self,
+    //                                                                                             @selector(viewWillAppear:),
+    //                                                                                             (IMP)swizzled_UIViewController__viewWillAppear_Imp);
+    // s_UIViewController__viewDidAppear_Imp = (void (*)(id, SEL, BOOL))hls_class_swizzleSelector(self,
+    //                                                                                            @selector(viewDidAppear:),
+    //                                                                                            (IMP)swizzled_UIViewController__viewDidAppear_Imp);
+    // s_UIViewController__viewWillDisappear_Imp = (void (*)(id, SEL, BOOL))hls_class_swizzleSelector(self,
+    //                                                                                                @selector(viewWillDisappear:),
+    //                                                                                                (IMP)swizzled_UIViewController__viewWillDisappear_Imp);
+    // s_UIViewController__viewDidDisappear_Imp = (void (*)(id, SEL, BOOL))hls_class_swizzleSelector(self,
+    //                                                                                               @selector(viewDidDisappear:),
+    //                                                                                               (IMP)swizzled_UIViewController__viewDidDisappear_Imp);
 }
 
 #pragma mark Object creation and destruction

--- a/version.xcconfig
+++ b/version.xcconfig
@@ -1,4 +1,4 @@
 //
 //  version.xcconfig
 //
-CURRENT_PROJECT_VERSION=2.1.2
+CURRENT_PROJECT_VERSION=2.1.3


### PR DESCRIPTION
…ion breaks 3rd party keyboards

Method swizzling dynamically replace implementation of a method (in this case apple code) with a custom implementation.

The issue is that these methods breaks our app when using a 3rd party keyboard.

https://rink.hockeyapp.net/manage/apps/10822/app_versions/29674/crash_reasons/44302209
